### PR TITLE
Ul-26-disable-email-backend-during-testing

### DIFF
--- a/project/app/settings.py
+++ b/project/app/settings.py
@@ -144,6 +144,6 @@ NINJA_DOCS_VIEW = "redoc"
 
 
 DEFAULT_FROM_EMAIL = "admin@money-wise.com.my"
-EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND', 'django.core.mail.backends.dummy.EmailBackend')
 VALIDATION_TOKEN_EXPIRY = timedelta(hours=36)
 HOSTNAME = 'http://localhost:8080'

--- a/tests/unit_tests/test_registration_service.py
+++ b/tests/unit_tests/test_registration_service.py
@@ -25,8 +25,7 @@ def test_that_new_user_cannot_be_created_if_already_present():
     
         assert str(exc) == "User john@example.com already registered."
 
-@pytest.mark.django_db 
-@pytest.mark.usefixtures("register_new_user")
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_that_validation_email_is_sent_when_new_user_is_successfully_saved_in_db(): 
     assert len(mail.outbox) == 1    
     message = mail.outbox[0] 
@@ -36,8 +35,7 @@ def test_that_validation_email_is_sent_when_new_user_is_successfully_saved_in_db
     assert message.to == ["john@example.com"]
     assert 'registration/validate?username=john@example.com&token=abc' in message.body 
 
-@pytest.mark.django_db 
-@pytest.mark.usefixtures("register_new_user") 
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_that_email_is_not_sent_when_user_info_is_updated(): 
     mail.outbox = [] 
 
@@ -73,8 +71,7 @@ def test_that_user_cannot_be_validated_if_validation_link_has_expired(client):
     user = get_user_model().objects.get(username='john@example.com')
     assert user.is_validated==False
     
-@pytest.mark.django_db
-@pytest.mark.usefixtures("register_new_user") 
+@override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
 def test_send_message_callback_sends_message_with_urlsafe_token_if_none_supplied(): 
     validation_token = get_user_model().objects.get(username='john@example.com').validation_token 
     body = mail.outbox[0].body 


### PR DESCRIPTION
Override settings on test requiring email sending to use locmem
email backend.